### PR TITLE
Add `create_index`for single index

### DIFF
--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -159,6 +159,16 @@ class Movie(mongox.Model):
 
 ### Indexes
 
+`Model.create_index()`: Creates a single index defined in `Meta` class.
+
+??? example
+    ```python
+    await Movie.create_index("name")
+    ```
+
+??? warning
+    This can raise `mongox.InvalidKeyException` if index is not found in `Meta` class.
+
 `Model.create_indexes()`: Creates indexes defined in `Meta` class.
 
 ??? example
@@ -195,4 +205,4 @@ class Movie(mongox.Model):
     ```
 
 ??? warning
-    This can raise `pymongo.errors.OperationFailure` exception.
+    This can raise `mongox.InvalidKeyException` if index is not found in `Meta` class.

--- a/mongox/__init__.py
+++ b/mongox/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.0.1"
 
 from mongox.database import Client, Collection, Database
-from mongox.exceptions import NoMatchFound
+from mongox.exceptions import InvalidKeyException, MultipleMatchesFound, NoMatchFound
 from mongox.fields import Field, ObjectId
 from mongox.index import Index, IndexType, Order
 from mongox.models import Model, Q
@@ -10,6 +10,8 @@ __all__ = [
     "Client",
     "Collection",
     "Database",
+    "InvalidKeyException",
+    "MultipleMatchesFound",
     "NoMatchFound",
     "Field",
     "ObjectId",

--- a/mongox/exceptions.py
+++ b/mongox/exceptions.py
@@ -8,3 +8,7 @@ class NoMatchFound(QueryException):
 
 class MultipleMatchesFound(QueryException):
     pass
+
+
+class InvalidKeyException(QueryException):
+    pass

--- a/mongox/expressions.py
+++ b/mongox/expressions.py
@@ -15,9 +15,7 @@ class QueryExpression:
     def __init__(
         self, key: typing.Union[str, "ModelField"], operator: str, value: typing.Any
     ) -> None:
-        if not isinstance(key, str):
-            key = key.alias
-        self.key = key
+        self.key = key if isinstance(key, str) else key.name
         self.operator = operator
         self.value = value
 
@@ -81,9 +79,7 @@ class SortExpression:
     """
 
     def __init__(self, key: typing.Union[str, "ModelField"], direction: Order) -> None:
-        if not isinstance(key, str):
-            key = key.alias
-        self.key = key
+        self.key = key if isinstance(key, str) else key.name
         self.direction = direction
 
     def compile(self) -> typing.Tuple[str, Order]:

--- a/mongox/expressions.py
+++ b/mongox/expressions.py
@@ -15,7 +15,7 @@ class QueryExpression:
     def __init__(
         self, key: typing.Union[str, "ModelField"], operator: str, value: typing.Any
     ) -> None:
-        self.key = key if isinstance(key, str) else key.name
+        self.key = key if isinstance(key, str) else key.alias
         self.operator = operator
         self.value = value
 
@@ -79,7 +79,7 @@ class SortExpression:
     """
 
     def __init__(self, key: typing.Union[str, "ModelField"], direction: Order) -> None:
-        self.key = key if isinstance(key, str) else key.name
+        self.key = key if isinstance(key, str) else key.alias
         self.direction = direction
 
     def compile(self) -> typing.Tuple[str, Order]:

--- a/mongox/fields.py
+++ b/mongox/fields.py
@@ -6,6 +6,9 @@ from pydantic.fields import ModelField as PydanticModelField
 
 from mongox.expressions import QueryExpression
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from mongox.models import Model
+
 __all__ = ["Field", "ObjectId"]
 
 
@@ -29,12 +32,19 @@ class ObjectId(bson.ObjectId):
         field_schema.update(type="string")
 
 
-class ModelField(PydanticModelField):
+class ModelField:
     """
     Custom ModelField to create query building
     """
 
-    __slots__: typing.Tuple[str, ...] = tuple()
+    __slots__: typing.Tuple[str, ...] = ("mongox_model", "name", "pydantic_field")
+
+    def __init__(
+        self, mongox_model: "Model", pydantic_field: PydanticModelField
+    ) -> None:
+        self.mongox_model = mongox_model
+        self.name = pydantic_field.alias
+        self.pydantic_field = pydantic_field
 
     def __lt__(self, other: typing.Any) -> QueryExpression:
         return QueryExpression(self.name, "$lt", other)

--- a/mongox/fields.py
+++ b/mongox/fields.py
@@ -6,9 +6,6 @@ from pydantic.fields import ModelField as PydanticModelField
 
 from mongox.expressions import QueryExpression
 
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from mongox.models import Model
-
 __all__ = ["Field", "ObjectId"]
 
 
@@ -32,19 +29,12 @@ class ObjectId(bson.ObjectId):
         field_schema.update(type="string")
 
 
-class ModelField:
+class ModelField(PydanticModelField):
     """
     Custom ModelField to create query building
     """
 
-    __slots__: typing.Tuple[str, ...] = ("mongox_model", "name", "pydantic_field")
-
-    def __init__(
-        self, mongox_model: "Model", pydantic_field: PydanticModelField
-    ) -> None:
-        self.mongox_model = mongox_model
-        self.name = pydantic_field.alias
-        self.pydantic_field = pydantic_field
+    __slots__: typing.Tuple[str, ...] = tuple()
 
     def __lt__(self, other: typing.Any) -> QueryExpression:
         return QueryExpression(self.name, "$lt", other)

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -3,9 +3,9 @@ import os
 import typing
 
 import pytest
-from pymongo import errors
 
 from mongox.database import Client
+from mongox.exceptions import InvalidKeyException
 from mongox.fields import ObjectId
 from mongox.index import Index, IndexType, Order
 from mongox.models import Model
@@ -34,11 +34,19 @@ async def test_create_indexes() -> None:
     index_names = await Movie.create_indexes()
     assert index_names == ["name", "year_genre"]
 
+    await Movie.drop_indexes()
+
+    index = await Movie.create_index("name")
+    assert index == "name"
+
+    with pytest.raises(InvalidKeyException):
+        await Movie.create_index("random_index")
+
 
 async def test_drop_index() -> None:
     await Movie.drop_index("name")
 
-    with pytest.raises(errors.OperationFailure):
+    with pytest.raises(InvalidKeyException):
         await Movie.drop_index("random_index")
 
 


### PR DESCRIPTION
Right now we have `create_indexes()`, `drop_index()` and `drop_indexes()` but a single `create_index` is required.

This adds the missing method.