### PR TITLE
Set `Client` default event loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,7 @@ import asyncio
 
 import mongox
 
-client = mongox.Client(
-    "mongodb://localhost:27017", get_event_loop=asyncio.get_running_loop
-)
+client = mongox.Client("mongodb://localhost:27017")
 db = client.get_database("test_db")
 
 

--- a/docs/defining_documents.md
+++ b/docs/defining_documents.md
@@ -10,9 +10,7 @@ import asyncio
 
 import mongox
 
-client = mongox.Client(
-    "mongodb://localhost:27017", get_event_loop=asyncio.get_running_loop
-)
+client = mongox.Client("mongodb://localhost:27017")
 db = client.get_database("test_db")
 
 
@@ -23,6 +21,20 @@ class Movie(mongox.Model):
     class Meta:
         collection = db.get_collection("movies")
 ```
+
+First we create a `mongox.Client` instance with the MongoDB URI.
+Then we get a database from client by calling `.get_database()`.
+
+If you want to have more control over the client event loop,
+you can specify a callable to get event loop at runtime:
+
+```python
+client = mongox.Client(
+    "mongodb://localhost:27017", get_event_loop=asyncio.get_running_loop
+)
+```
+
+By default, `mongox.Client` will use `asyncio.get_running_loop`.
 
 Model attributes are defined the same way as Pydantic. The `Movie` class
 is both a mongox `Model` and also a pydantic `BaseModel`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,9 +62,7 @@ import asyncio
 
 import mongox
 
-client = mongox.Client(
-    "mongodb://localhost:27017", get_event_loop=asyncio.get_running_loop
-)
+client = mongox.Client("mongodb://localhost:27017")
 db = client.get_database("test_db")
 
 

--- a/mongox/database.py
+++ b/mongox/database.py
@@ -44,11 +44,12 @@ class Client:
     def __init__(
         self,
         uri: str = "mongodb://localhost:27017",
-        get_event_loop: typing.Callable[[], asyncio.AbstractEventLoop] = None,
+        get_event_loop: typing.Callable[
+            [], asyncio.AbstractEventLoop
+        ] = asyncio.get_event_loop,
     ) -> None:
         self._client = AsyncIOMotorClient(uri)
-        if get_event_loop:
-            self._client.get_io_loop = get_event_loop
+        self._client.get_io_loop = get_event_loop
 
     @property
     def address(self) -> typing.Tuple[str, int]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from mongox.database import Client
 
 database_uri = os.environ.get("DATABASE_URI", "mongodb://localhost:27017")
-client = Client(get_event_loop=asyncio.get_running_loop)
+client = Client(database_uri, get_event_loop=asyncio.get_running_loop)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
We don't need to specify this:

```python
client = mongox.Client(
    "mongodb://localhost:27017", get_event_loop=asyncio.get_running_loop
)
```

The event loop will be specified by default:

```python
client = mongox.Client("mongodb://localhost:27017")
```