### PR TITLE
Removing Meta class from Model definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,9 @@ client = mongox.Client("mongodb://localhost:27017")
 db = client.get_database("test_db")
 
 
-class Movie(mongox.Model):
+class Movie(mongox.Model, db=db, collection="movies"):
     name: str
     year: int
-
-    class Meta:
-        collection = db.get_collection("movies")
 ```
 
 Now you can create some instances and insert them into the database:

--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -1,15 +1,17 @@
-All examples are provided for the following collection (without extra boilerplate):
+All examples are provided for the following collection:
 
 ```python
+import asyncio
+
 import mongox
 
+client = mongox.Client("mongodb://localhost:27017")
+db = client.get_database("test_db")
 
-class Movie(mongox.Model):
+
+class Movie(mongox.Model, db=db, collection="movies"):
     name: str
     year: int
-
-    class Meta:
-        indexes = [mongox.Index("name", unique=True)]
 ```
 
 ### Model methods

--- a/docs/defining_documents.md
+++ b/docs/defining_documents.md
@@ -14,12 +14,9 @@ client = mongox.Client("mongodb://localhost:27017")
 db = client.get_database("test_db")
 
 
-class Movie(mongox.Model):
+class Movie(mongox.Model, db=db):
     name: str
     year: int
-
-    class Meta:
-        collection = db.get_collection("movies")
 ```
 
 First we create a `mongox.Client` instance with the MongoDB URI.
@@ -105,17 +102,16 @@ Index definition should be inside the `Meta` class of the Model.
 import mongox
 
 
-class Movie(mongox.Model):
+indexes = [
+    mongox.Index("name", unique=True),
+    mongox.Index(keys=[("year", mongox.Order.DESCENDING), ("genre", mongox.IndexType.HASHED)]),
+]
+
+
+class Movie(mongox.Model, db=db, indexes=indexes):
     name: str
     genre: str
-    year: int
-
-    class Meta:
-        collection = db.get_collection("movies")
-        indexes = [
-            mongox.Index("name", unique=True),
-            mongox.Index(keys=[("year", mongox.Order.DESCENDING), ("genre", mongox.IndexType.HASHED)]),
-        ]
+    year: int 
 ```
 
 As you can see `Meta` class expects `indexes` to be a list of `Index` objects.

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,12 +69,9 @@ client = mongox.Client("mongodb://localhost:27017")
 db = client.get_database("test_db")
 
 
-class Movie(mongox.Model):
+class Movie(mongox.Model, db=db, collection="movies):
     name: str
     year: int
-
-    class Meta:
-        collection = db.get_collection("movies")
 ```
 
 Now you can create some instances and insert them into the database:

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -9,12 +9,9 @@ client = mongox.Client(
 db = client.get_database("test_db")
 
 
-class Movie(mongox.Model):
+class Movie(mongox.Model, db=db):
     name: str
     year: int = mongox.Field(gt=1800, lt=2050)
-
-    class Meta:
-        collection = db.get_collection("movies")
 
 
 async def main():

--- a/examples/embedded_models.py
+++ b/examples/embedded_models.py
@@ -13,12 +13,9 @@ class Genre(mongox.EmbeddedModel):
     name: str = mongox.Field(min_length=5)
 
 
-class Movie(mongox.Model):
+class Movie(mongox.Model, db=db, collection="movies"):
     name: str
     genre: Genre
-
-    class Meta:
-        collection = db.get_collection("movies")
 
 
 async def main():

--- a/mongox/_helpers.py
+++ b/mongox/_helpers.py
@@ -1,0 +1,6 @@
+import re
+
+
+def normalize_class_name(name: str) -> str:
+    underscored = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", underscored).lower()

--- a/tests/test_embedded_models.py
+++ b/tests/test_embedded_models.py
@@ -32,15 +32,12 @@ class Genre(EmbeddedModel):
     title: str
 
 
-class Movie(Model):
+class Movie(Model, db=db, collection="movies"):
     actors: typing.List[Actor]
     director: Crew
     name: str
     genre: Genre
     year: int
-
-    class Meta:
-        collection = db.get_collection("movies")
 
 
 async def test_embedded_model() -> None:

--- a/tests/test_embedded_models.py
+++ b/tests/test_embedded_models.py
@@ -32,7 +32,7 @@ class Genre(EmbeddedModel):
     title: str
 
 
-class Movie(Model, db=db, collection="movies"):
+class Movie(Model, db=db):
     actors: typing.List[Actor]
     director: Crew
     name: str

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -17,17 +17,16 @@ client = Client(database_uri, get_event_loop=asyncio.get_running_loop)
 db = client.get_database("test_db")
 
 
-class Movie(Model):
+indexes = [
+    Index("name", unique=True),
+    Index(keys=[("year", Order.DESCENDING), ("genre", IndexType.HASHED)]),
+]
+
+
+class Movie(Model, db=db, indexes=indexes):
     name: str
     year: int
     uuid: typing.Optional[ObjectId]
-
-    class Meta:
-        collection = db.get_collection("movies")
-        indexes = [
-            Index("name", unique=True),
-            Index(keys=[("year", Order.DESCENDING), ("genre", IndexType.HASHED)]),
-        ]
 
 
 async def test_create_indexes() -> None:

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -19,12 +19,9 @@ client = Client(database_uri, get_event_loop=asyncio.get_running_loop)
 db = client.get_database("test_db")
 
 
-class Movie(Model):
+class Movie(Model, db=db):
     name: str
     year: int
-
-    class Meta:
-        collection = db.get_collection("movies")
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
As it was suggested in #4, I think it would be nice to remove the Meta class, at least from the documentation but it will still work if defined:


```python
class Movie(Model, db=db, collection="movies"):
    name: str
    year: int
```

Instead of:


```python
class Movie(mongox.Model):
    name: str
    year: int

    class Meta:
        collection = db.get_collection("movies")
```

We could also remove db and accept `Collection` instances, but I think this will be easier.

**Update**:
Ass suggested by @MAD-py we the `db` argument will be required and the `collection` will be `<class_name>s` if not provided.