### PR TITLE
Fixed autouse fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,4 +19,5 @@ def event_loop() -> typing.Generator[asyncio.AbstractEventLoop, None, None]:
 
 @pytest.fixture(autouse=True, scope="session")
 async def test_database() -> None:
+    yield
     await client.drop_database("test_db")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,5 +19,6 @@ def event_loop() -> typing.Generator[asyncio.AbstractEventLoop, None, None]:
 
 @pytest.fixture(autouse=True, scope="session")
 async def test_database() -> typing.AsyncGenerator:
+    await client.drop_database("test_db")
     yield
     await client.drop_database("test_db")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,6 @@ def event_loop() -> typing.Generator[asyncio.AbstractEventLoop, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
-async def test_database() -> None:
+async def test_database() -> typing.AsyncGenerator:
     yield
     await client.drop_database("test_db")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,6 +35,9 @@ class Movie(Model):
 
 @pytest.fixture(scope="function", autouse=True)
 async def prepare_database() -> typing.AsyncGenerator:
+    await Movie.drop_indexes(force=True)
+    await Movie.query().delete()
+    await Movie.create_indexes()
     yield
     await Movie.drop_indexes(force=True)
     await Movie.query().delete()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,6 +35,7 @@ class Movie(Model):
 
 @pytest.fixture(scope="function", autouse=True)
 async def prepare_database() -> None:
+    yield
     await Movie.drop_indexes(force=True)
     await Movie.query().delete()
     await Movie.create_indexes()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,7 +34,7 @@ class Movie(Model):
 
 
 @pytest.fixture(scope="function", autouse=True)
-async def prepare_database() -> None:
+async def prepare_database() -> typing.AsyncGenerator:
     yield
     await Movie.drop_indexes(force=True)
     await Movie.query().delete()


### PR DESCRIPTION
@aminalaee autouse fixutres were getting called at the beginning of each test rather than the end which was leading to test_db not being empty at the end

`Movie.query().all()` returned this earlier
```
[Movie(id=ObjectId('61ed0cd87f46c40b190810e6'), name='Forrest Gump', year=2003, uuid=None),
 Movie(id=ObjectId('61ed0cd87f46c40b190810e9'), name='Venom', year=2021, uuid=None),
 Movie(id=ObjectId('61ed0cd87f46c40b190810eb'), name='Eternals', year=2021, uuid=None)]
```