### PR TITLE
Remove Meta class docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ movie = await Movie(name="Forrest Gump", year=1994).insert()
 
 The returned result will be a `Movie` instance, and `mypy`
 will understand that this is a `Movie` instance.
-So you will have type hints and validations everywhere:
-
-<img alt="MongoX insert screenshot" src="https://user-images.githubusercontent.com/19784933/141309006-94785d1b-c0de-4fde-8b7d-f59253657d64.png">
+So you will have type hints and validations everywhere.
 
 Now you can fetch some data from the database.
 
@@ -98,9 +96,6 @@ The returned result will be a `Movie` instance, and `mypy`
 will understand that this is a `Movie` instance.
 
 This will have great IDE support, autocompletion and validation.
-
-<img alt="MongoX get screenshot" src="https://user-images.githubusercontent.com/19784933/141615279-f4534246-e09d-4d5e-90f6-32f0a3807769.png">
-
 
 Or you can use `Movie` fields instead of dictionaries in the query (less room for bugs):
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,6 @@ You can use the same pattern as PyMongo/Motor:
 movie = await Movie.query({"name": "Forrest Gump"}).get()
 ```
 
-The returned result will be a `Movie` instance, and `mypy`
-will understand that this is a `Movie` instance.
-
-This will have great IDE support, autocompletion and validation.
-
 Or you can use `Movie` fields instead of dictionaries in the query (less room for bugs):
 
 ```python

--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -161,7 +161,7 @@ class Movie(mongox.Model, db=db, collection="movies"):
 
 ### Indexes
 
-`Model.create_index()`: Creates a single index defined in `Meta` class.
+`Model.create_index()`: Creates a single index defined in `Model` class.
 
 ??? example
     ```python
@@ -169,9 +169,9 @@ class Movie(mongox.Model, db=db, collection="movies"):
     ```
 
 ??? warning
-    This can raise `mongox.InvalidKeyException` if index is not found in `Meta` class.
+    This can raise `mongox.InvalidKeyException` if index is not found in `Model` class.
 
-`Model.create_indexes()`: Creates indexes defined in `Meta` class.
+`Model.create_indexes()`: Creates indexes defined in `Model` class.
 
 ??? example
     ```python
@@ -186,7 +186,7 @@ class Movie(mongox.Model, db=db, collection="movies"):
 
 ??? example
     ```python
-    # Drops indexes defined in Meta class.
+    # Drops indexes defined in Movie class.
     await Movie.drop_indexes()
     ```
 
@@ -207,4 +207,4 @@ class Movie(mongox.Model, db=db, collection="movies"):
     ```
 
 ??? warning
-    This can raise `mongox.InvalidKeyException` if index is not found in `Meta` class.
+    This can raise `mongox.InvalidKeyException` if index is not found in `Model` class.

--- a/docs/defining_documents.md
+++ b/docs/defining_documents.md
@@ -38,9 +38,6 @@ is both a mongox `Model` and also a pydantic `BaseModel`.
 
 Now we have a `Movie` collection with attributes `name` and `year`.
 
-!!! note
-    The `Meta` class is required since we need to know which collection this belongs to.
-
 ### Field validation
 
 You can add field-level validations by using `mongox.Field`.
@@ -96,7 +93,7 @@ the Pydantic docs [here](https://pydantic-docs.helpmanual.io/usage/schema/#field
 
 ### Defining indexes
 
-Index definition should be inside the `Meta` class of the Model.
+Mongox models accept `indexes` as a list of `mongox.Index` instances:
 
 ```python
 import mongox
@@ -113,8 +110,6 @@ class Movie(mongox.Model, db=db, indexes=indexes):
     genre: str
     year: int 
 ```
-
-As you can see `Meta` class expects `indexes` to be a list of `Index` objects.
 
 For creating `Index` objects we have two options, for simple cases we can do:
 
@@ -140,7 +135,8 @@ Or to drop the indexes:
 await Movie.drop_indexes()
 ```
 
-Note that this will only drop indexes defined in `Meta` class.
+Note that this will only drop indexes defined in `Movie` model and
+won't affect the ones manually created.
 To drop all indexes, even those not defined here you can pass `force=True`:
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,9 +82,7 @@ movie = await Movie(name="Forrest Gump", year=1994).insert()
 
 The returned result will be a `Movie` instance, and `mypy`
 will understand that this is a `Movie` instance.
-So you will have type hints and validations everywhere:
-
-<img alt="MongoX insert screenshot" src="https://user-images.githubusercontent.com/19784933/141309006-94785d1b-c0de-4fde-8b7d-f59253657d64.png">
+So you will have type hints and validations everywhere.
 
 Now you can fetch some data from the database.
 
@@ -98,9 +96,6 @@ The returned result will be a `Movie` instance, and `mypy`
 will understand that this is a `Movie` instance.
 
 This will have great IDE support, autocompletion and validation.
-
-<img alt="MongoX get screenshot" src="https://user-images.githubusercontent.com/19784933/141615279-f4534246-e09d-4d5e-90f6-32f0a3807769.png">
-
 
 Or you can use `Movie` fields instead of dictionaries in the query (less room for bugs):
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,11 +92,6 @@ You can use the same pattern as PyMongo/Motor:
 movie = await Movie.query({"name": "Forrest Gump"}).get()
 ```
 
-The returned result will be a `Movie` instance, and `mypy`
-will understand that this is a `Movie` instance.
-
-This will have great IDE support, autocompletion and validation.
-
 Or you can use `Movie` fields instead of dictionaries in the query (less room for bugs):
 
 ```python

--- a/docs/queriying_documents.md
+++ b/docs/queriying_documents.md
@@ -42,9 +42,6 @@ to know which fields are required.
 
 And you will also know that the result of `insert` will be a `Movie` instance.
 
-<img alt="MongoX insert screenshot" src="https://user-images.githubusercontent.com/19784933/141309006-94785d1b-c0de-4fde-8b7d-f59253657d64.png">
-
-
 This will lead to more productivity and fewer runtime errors.
 
 Let's say you try to access `genre` of movie:
@@ -82,8 +79,6 @@ movie = await Movie.query(Movie.name == "Forrest Gump").get()
 
 Here you will again have graet IDE and MyPy support,
 as they will know the returned type of `get` will be a `Movie`.
-
-<img alt="MongoX insert screenshot" src="https://user-images.githubusercontent.com/19784933/141309006-94785d1b-c0de-4fde-8b7d-f59253657d64.png">
 
 So you can access `movie` attributes safely.
 


### PR DESCRIPTION
After removing `Meta` from public API, there are still some docs referring to it. This PR removes those mentions.