### PR TITLE
Feat: Add `insert_many` method

### DIFF
--- a/docs/queriying_documents.md
+++ b/docs/queriying_documents.md
@@ -34,6 +34,15 @@ This will insert the following document in MongoDB:
 {"name": "Forrest Gump", "year": 1994, "tags": ["Comedy", "Drama"]}
 ```
 
+If you want to insert many documents at once, just use `insert_many` method:
+```python
+movies = [
+    Movie(name="Forrest Gump", year=1994, tags=["Comedy", "Drama"]),
+    Movie(name="The Shawshank Redemption", year=1994, tags=["Drama"]),
+]
+movies = await Movie.insert_many(movies)
+```
+
 The great thing about MongoX is that since it's fully type annotated,
 you will have great `mypy` and IDE support.
 

--- a/docs/queriying_documents.md
+++ b/docs/queriying_documents.md
@@ -13,6 +13,8 @@ class Movie(mongox.Model):
 
 ### Inserting documents
 
+#### Single documents
+
 In order to work with documents we'll first need to insert some.
 
 MongoX provides an `insert` method to the document instances.
@@ -34,7 +36,10 @@ This will insert the following document in MongoDB:
 {"name": "Forrest Gump", "year": 1994, "tags": ["Comedy", "Drama"]}
 ```
 
+#### Bulk documents
+
 If you want to insert many documents at once, just use `insert_many` method:
+
 ```python
 movies = [
     Movie(name="Forrest Gump", year=1994, tags=["Comedy", "Drama"]),

--- a/docs/queriying_documents.md
+++ b/docs/queriying_documents.md
@@ -13,7 +13,7 @@ class Movie(mongox.Model):
 
 ### Inserting documents
 
-#### Single documents
+#### Single insert
 
 In order to work with documents we'll first need to insert some.
 
@@ -36,7 +36,7 @@ This will insert the following document in MongoDB:
 {"name": "Forrest Gump", "year": 1994, "tags": ["Comedy", "Drama"]}
 ```
 
-#### Bulk documents
+#### Bulk insert
 
 If you want to insert many documents at once, just use `insert_many` method:
 

--- a/mongox/exceptions.py
+++ b/mongox/exceptions.py
@@ -16,3 +16,4 @@ class InvalidKeyException(QueryException):
 
 class InvalidObjectIdException(QueryException):
     pass
+

--- a/mongox/models.py
+++ b/mongox/models.py
@@ -337,18 +337,12 @@ class Model(pydantic.BaseModel, metaclass=ModelMetaClass):
         return self
 
     @classmethod
-    async def insert_one(cls: typing.Type[T], model: T) -> T:
-        if not isinstance(model, cls):
-            raise TypeError(f"Model must be of type {cls.__name__}")
-        return await model.insert()
-
-    @classmethod
     async def insert_many(cls: typing.Type[T], models: typing.List[T]) -> typing.List[T]:
         if not all(isinstance(model, cls) for model in models):
             raise TypeError(f"All models must be of type {cls.__name__}")
 
-        datas = (model.dict(exclude={"id"}) for model in models)
-        results = await cls.Meta.collection._collection.insert_many(datas)
+        data = (model.dict(exclude={"id"}) for model in models)
+        results = await cls.Meta.collection._collection.insert_many(data)
         for model, inserted_id in zip(models, results.inserted_ids):
             model.id = inserted_id
         return models

--- a/mongox/models.py
+++ b/mongox/models.py
@@ -337,6 +337,23 @@ class Model(pydantic.BaseModel, metaclass=ModelMetaClass):
         return self
 
     @classmethod
+    async def insert_one(cls: typing.Type[T], model: T) -> T:
+        if not isinstance(model, cls):
+            raise TypeError(f"Model must be of type {cls.__name__}")
+        return await model.insert()
+
+    @classmethod
+    async def insert_many(cls: typing.Type[T], models: typing.List[T]) -> typing.List[T]:
+        if not all(isinstance(model, cls) for model in models):
+            raise TypeError(f"All models must be of type {cls.__name__}")
+
+        datas = (model.dict(exclude={"id"}) for model in models)
+        results = await cls.Meta.collection._collection.insert_many(datas)
+        for model, inserted_id in zip(models, results.inserted_ids):
+            model.id = inserted_id
+        return models
+
+    @classmethod
     async def create_index(cls, name: str) -> str:
         """Create single index from Meta indexes by name.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -495,36 +495,9 @@ async def test_model_get_by_id() -> None:
         await Movie.get_by_id(secrets.token_hex(12))
 
 
-async def test_model_insert_one() -> None:
-    movie = Movie(name="The Godfather", year=1972)
-    movie_db = await Movie.insert_one(movie)
-    assert movie_db.name == "The Godfather"
-    assert movie_db.year == 1972
-    assert isinstance(movie.id, bson.ObjectId)
-
-    with pytest.raises(pydantic.error_wrappers.ValidationError) as exc:
-        movie = Movie(name="Avengers", year=2017, uuid="1")
-        await Movie.insert_one(movie)  # type: ignore
-    assert exc.value.errors() == [
-        {"loc": ("uuid",), "msg": "Invalid ObjectId", "type": "value_error"}
-    ]
-
-    with pytest.raises(errors.DuplicateKeyError):
-        movie = Movie(name="The Godfather", year=1972)
-        await Movie.insert_one(movie)
-
-    class Book(Model, db=db, indexes=indexes):
-        name: str
-        year: int
-
-    with pytest.raises(TypeError):
-        book = Book(name="The Book", year=1972)
-        await Movie.insert_one(book)  # type: ignore
-
-
 async def test_model_insert_many() -> None:
     movies = []
-    movie_names = ["The Dark Knight", "The Dark Knight Rises", "The Godfather"]
+    movie_names = ("The Dark Knight", "The Dark Knight Rises", "The Godfather")
     for movie_name in movie_names:
         movies.append(Movie(name=movie_name, year=random.randint(1970, 2020)))
     movies_db = await Movie.insert_many(movies)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import random
 import secrets
 import typing
 
@@ -492,3 +493,51 @@ async def test_model_get_by_id() -> None:
 
     with pytest.raises(NoMatchFound):
         await Movie.get_by_id(secrets.token_hex(12))
+
+
+async def test_model_insert_one() -> None:
+    movie = Movie(name="The Godfather", year=1972)
+    movie_db = await Movie.insert_one(movie)
+    assert movie_db.name == "The Godfather"
+    assert movie_db.year == 1972
+    assert isinstance(movie.id, bson.ObjectId)
+
+    with pytest.raises(pydantic.error_wrappers.ValidationError) as exc:
+        movie = Movie(name="Avengers", year=2017, uuid="1")
+        await Movie.insert_one(movie)  # type: ignore
+    assert exc.value.errors() == [
+        {"loc": ("uuid",), "msg": "Invalid ObjectId", "type": "value_error"}
+    ]
+
+    with pytest.raises(errors.DuplicateKeyError):
+        movie = Movie(name="The Godfather", year=1972)
+        await Movie.insert_one(movie)
+
+    class Book(Model, db=db, indexes=indexes):
+        name: str
+        year: int
+
+    with pytest.raises(TypeError):
+        book = Book(name="The Book", year=1972)
+        await Movie.insert_one(book)  # type: ignore
+
+
+async def test_model_insert_many() -> None:
+    movies = []
+    movie_names = ["The Dark Knight", "The Dark Knight Rises", "The Godfather"]
+    for movie_name in movie_names:
+        movies.append(Movie(name=movie_name, year=random.randint(1970, 2020)))
+    movies_db = await Movie.insert_many(movies)
+    for movie, movie_db in zip(movies, movies_db):
+        assert movie.name == movie_db.name
+        assert movie.year == movie_db.year
+        assert isinstance(movie.id, bson.ObjectId)
+
+    class Book(Model, db=db, indexes=indexes):
+        name: str
+        year: int
+
+    with pytest.raises(TypeError):
+        book = Book(name="The Book", year=1972)
+        movie = Movie(name="Inception", year=2010)
+        await Movie.insert_many([book, movie])  # type: ignore


### PR DESCRIPTION
Support class method `insert_many` and `insert_one` https://github.com/aminalaee/mongox/issues/46

Refer to motor [insert_many](https://motor.readthedocs.io/en/stable/api-tornado/motor_collection.html#motor.motor_tornado.MotorCollection.insert_many) document.